### PR TITLE
test: add unit tests for Area module to validate stringify and parse functionality

### DIFF
--- a/src/Magic/Spell/Area.ts
+++ b/src/Magic/Spell/Area.ts
@@ -1,42 +1,42 @@
 import { Debugger, Stringifier } from '@wowfinder/ts-utils';
 import { Length } from '../../Scalar';
 
-type SpellSelf = {
+type SpellAreaSelf = {
     spellAreaType: 'self';
 };
 
-type SpellPoint = {
+type SpellAreaPoint = {
     spellAreaType: 'point';
 };
 
-type SpellCone = {
+type SpellAreaCone = {
     spellAreaType: 'cone';
     radius: Length;
 };
 
-type SpellCube = {
+type SpellAreaCube = {
     spellAreaType: 'cube';
     size: Length;
 };
 
-type SpellLine = {
+type SpellAreaLine = {
     spellAreaType: 'line';
     length: Length;
 };
 
-type SpellSphere = {
+type SpellAreaSphere = {
     spellAreaType: 'sphere';
     radius: Length;
     selfCentered: boolean;
 };
 
 type SpellArea =
-    | SpellSelf
-    | SpellPoint
-    | SpellCone
-    | SpellCube
-    | SpellLine
-    | SpellSphere;
+    | SpellAreaSelf
+    | SpellAreaPoint
+    | SpellAreaCone
+    | SpellAreaCube
+    | SpellAreaLine
+    | SpellAreaSphere;
 
 function stringify(
     value: SpellArea,
@@ -66,16 +66,16 @@ function stringify(
 }
 
 const partialParsers = {
-    cone: (length?: Length): SpellCone | undefined =>
+    cone: (length?: Length): SpellAreaCone | undefined =>
         length ? { spellAreaType: 'cone', radius: length } : undefined,
-    cube: (length?: Length): SpellCube | undefined =>
+    cube: (length?: Length): SpellAreaCube | undefined =>
         length ? { spellAreaType: 'cube', size: length } : undefined,
-    line: (length?: Length): SpellLine | undefined =>
+    line: (length?: Length): SpellAreaLine | undefined =>
         length ? { spellAreaType: 'line', length } : undefined,
     sphere: {
         base:
             (selfCentered: boolean) =>
-            (length?: Length): SpellSphere | undefined =>
+            (length?: Length): SpellAreaSphere | undefined =>
                 length
                     ? {
                           spellAreaType: 'sphere',
@@ -83,15 +83,15 @@ const partialParsers = {
                           selfCentered,
                       }
                     : undefined,
-        point: (length?: Length): SpellSphere | undefined =>
+        point: (length?: Length): SpellAreaSphere | undefined =>
             partialParsers.sphere.base(false)(length),
-        self: (length?: Length): SpellSphere | undefined =>
+        self: (length?: Length): SpellAreaSphere | undefined =>
             partialParsers.sphere.base(true)(length),
     },
 };
 
 function tryParseArea(input: string): SpellArea | undefined {
-    const matches = /^([a-z.]+)\s*(\(.*\))?$/.exec(input.toLowerCase());
+    const matches = /^([a-z.]+)\s*(?:\((.*)\))?$/.exec(input.toLowerCase());
     if (!matches) {
         return undefined;
     }
@@ -126,12 +126,15 @@ function parseArea(
     return tryParseArea(input) ?? defaultValue;
 }
 
-export type {
-    SpellArea,
-    SpellPoint,
-    SpellCone,
-    SpellCube,
-    SpellLine,
-    SpellSphere,
+export {
+    type SpellArea,
+    type SpellAreaSelf,
+    type SpellAreaPoint,
+    type SpellAreaCone,
+    type SpellAreaCube,
+    type SpellAreaLine,
+    type SpellAreaSphere,
+    stringify,
+    tryParseArea,
+    parseArea,
 };
-export { stringify, tryParseArea, parseArea };

--- a/src/Magic/Spell/__tests__/Area.test.ts
+++ b/src/Magic/Spell/__tests__/Area.test.ts
@@ -13,7 +13,7 @@ import {
     type SpellAreaSphere,
 } from '../Area';
 
-function t(key: string, params?: Length): string {
+function t(key: string, params?: Record<string, Length>): string {
     if (params && Object.keys(params).length) {
         return `${key} ${JSON.stringify(params)}`;
     }

--- a/src/Magic/Spell/__tests__/Area.test.ts
+++ b/src/Magic/Spell/__tests__/Area.test.ts
@@ -13,7 +13,7 @@ import {
     type SpellAreaSphere,
 } from '../Area';
 
-function t(key: string, params?: {}): string {
+function t(key: string, params?: Length): string {
     if (params && Object.keys(params).length) {
         return `${key} ${JSON.stringify(params)}`;
     }
@@ -100,28 +100,28 @@ describe('Area', () => {
             const result = tryParseArea('cone(15 foot)');
             expect(result).toEqual({
                 spellAreaType: 'cone',
-                radius: { ...mkLength(15) },
+                radius: mkLength(15),
             });
         });
         it('should parse correctly a cube area value', () => {
             const result = tryParseArea('cube(20 foot)');
             expect(result).toEqual({
                 spellAreaType: 'cube',
-                size: { ...mkLength(20) },
+                size: mkLength(20),
             });
         });
         it('should parse correctly a line area value', () => {
             const result = tryParseArea('line(30 foot)');
             expect(result).toEqual({
                 spellAreaType: 'line',
-                length: { ...mkLength(30) },
+                length: mkLength(30),
             });
         });
         it('should parse correctly a sphere area value, self-centered', () => {
             const result = tryParseArea('sphere.self(40 foot)');
             expect(result).toEqual({
                 spellAreaType: 'sphere',
-                radius: { ...mkLength(40) },
+                radius: mkLength(40),
                 selfCentered: true,
             });
         });
@@ -129,7 +129,7 @@ describe('Area', () => {
             const result = tryParseArea('sphere.point(50 foot)');
             expect(result).toEqual({
                 spellAreaType: 'sphere',
-                radius: { ...mkLength(50) },
+                radius: mkLength(50),
                 selfCentered: false,
             });
         });

--- a/src/Magic/Spell/__tests__/Area.test.ts
+++ b/src/Magic/Spell/__tests__/Area.test.ts
@@ -1,0 +1,182 @@
+import { LengthUnit } from '@wowfinder/ts-enums';
+import { Length } from '../../../Scalar';
+import {
+    stringify,
+    tryParseArea,
+    parseArea,
+    type SpellArea,
+    type SpellAreaSelf,
+    type SpellAreaPoint,
+    type SpellAreaCone,
+    type SpellAreaCube,
+    type SpellAreaLine,
+    type SpellAreaSphere,
+} from '../Area';
+
+function t(key: string, params?: {}): string {
+    if (params && Object.keys(params).length) {
+        return `${key} ${JSON.stringify(params)}`;
+    }
+    return key;
+}
+
+function mkLength(feet: number): Length {
+    return new Length({ value: feet, unit: LengthUnit.foot });
+}
+
+describe('Area', () => {
+    describe('stringify', () => {
+        it('should stringify a value of subtype SpellAreaSelf', () => {
+            const area: SpellAreaSelf = { spellAreaType: 'self' };
+            const result = stringify(area, t);
+            expect(result).toBe('magic.area.self');
+        });
+        it('should stringify a value of subtype SpellAreaPoint', () => {
+            const area: SpellAreaPoint = { spellAreaType: 'point' };
+            const result = stringify(area, t);
+            expect(result).toBe('magic.area.point');
+        });
+        it('should stringify a value of subtype SpellAreaCone', () => {
+            const area: SpellAreaCone = {
+                spellAreaType: 'cone',
+                radius: mkLength(5),
+            };
+            const result = stringify(area, t);
+            expect(result).toBe('magic.area.cone {"radius":"5 units.foot"}');
+        });
+        it('should stringify a value of subtype SpellAreaCube', () => {
+            const area: SpellAreaCube = {
+                spellAreaType: 'cube',
+                size: mkLength(5),
+            };
+            const result = stringify(area, t);
+            expect(result).toBe('magic.area.cube {"size":"5 units.foot"}');
+        });
+        it('should stringify a value of subtype SpellAreaLine', () => {
+            const area: SpellAreaLine = {
+                spellAreaType: 'line',
+                length: mkLength(5),
+            };
+            const result = stringify(area, t);
+            expect(result).toBe('magic.area.line {"length":"5 units.foot"}');
+        });
+        it('should stringify a value of subtype SpellAreaSphere, self-centered', () => {
+            const area: SpellAreaSphere = {
+                spellAreaType: 'sphere',
+                radius: mkLength(5),
+                selfCentered: true,
+            };
+            const result = stringify(area, t);
+            expect(result).toBe(
+                'magic.area.sphere.self {"radius":"5 units.foot"}',
+            );
+        });
+        it('should stringify a value of subtype SpellAreaSphere, point-centered', () => {
+            const area: SpellAreaSphere = {
+                spellAreaType: 'sphere',
+                radius: mkLength(5),
+                selfCentered: false,
+            };
+            const result = stringify(area, t);
+            expect(result).toBe(
+                'magic.area.sphere.point {"radius":"5 units.foot"}',
+            );
+        });
+        it('should throw when attempting to stringify a value of an unknown subtype', () => {
+            const area = { spellAreaType: 'unknown' } as unknown as SpellArea;
+            expect(() => stringify(area, t)).toThrow();
+        });
+    });
+    describe('tryParseArea', () => {
+        it('should parse correctly the keyword value `self`', () => {
+            const result = tryParseArea('self');
+            expect(result).toEqual({ spellAreaType: 'self' });
+        });
+        it('should parse correctly the keyword value `point`', () => {
+            const result = tryParseArea('point');
+            expect(result).toEqual({ spellAreaType: 'point' });
+        });
+        it('should parse correctly a cone area value', () => {
+            const result = tryParseArea('cone(15 foot)');
+            expect(result).toEqual({
+                spellAreaType: 'cone',
+                radius: { ...mkLength(15) },
+            });
+        });
+        it('should parse correctly a cube area value', () => {
+            const result = tryParseArea('cube(20 foot)');
+            expect(result).toEqual({
+                spellAreaType: 'cube',
+                size: { ...mkLength(20) },
+            });
+        });
+        it('should parse correctly a line area value', () => {
+            const result = tryParseArea('line(30 foot)');
+            expect(result).toEqual({
+                spellAreaType: 'line',
+                length: { ...mkLength(30) },
+            });
+        });
+        it('should parse correctly a sphere area value, self-centered', () => {
+            const result = tryParseArea('sphere.self(40 foot)');
+            expect(result).toEqual({
+                spellAreaType: 'sphere',
+                radius: { ...mkLength(40) },
+                selfCentered: true,
+            });
+        });
+        it('should parse correctly a sphere area value, point-centered', () => {
+            const result = tryParseArea('sphere.point(50 foot)');
+            expect(result).toEqual({
+                spellAreaType: 'sphere',
+                radius: { ...mkLength(50) },
+                selfCentered: false,
+            });
+        });
+        it('should return undefined when parsing an unknown keyword', () => {
+            const result = tryParseArea('unknown');
+            expect(result).toBeUndefined();
+        });
+        it('should return undefined when parsing an invalid format', () => {
+            const result = tryParseArea('cone 15 foot');
+            expect(result).toBeUndefined();
+        });
+        it('should return undefined when parsing a cone area with invalid radius', () => {
+            const result = tryParseArea('cone(fifteen foot)');
+            expect(result).toBeUndefined();
+        });
+        it('should return undefined when parsing a cube area with invalid size', () => {
+            const result = tryParseArea('cube(twenty foot)');
+            expect(result).toBeUndefined();
+        });
+        it('should return undefined when parsing a line area with invalid length', () => {
+            const result = tryParseArea('line(thirty foot)');
+            expect(result).toBeUndefined();
+        });
+        it('should return undefined when parsing a sphere area with invalid radius', () => {
+            const result = tryParseArea('sphere.self(forty foot)');
+            expect(result).toBeUndefined();
+        });
+    });
+    describe('parseArea', () => {
+        it('should parse a valid area string', () => {
+            const result = parseArea('cone(15 foot)');
+            expect(result).toEqual({
+                spellAreaType: 'cone',
+                radius: { ...mkLength(15) },
+            });
+            expect(result && stringify(result, t)).toBe(
+                'magic.area.cone {"radius":"15 units.foot"}',
+            );
+        });
+        it('should return the default area when parsing an invalid area string', () => {
+            const defaultArea = { spellAreaType: 'self' } as const;
+            const result = parseArea('invalid area', defaultArea);
+            expect(result).toEqual(defaultArea);
+        });
+        it('should provide a default value for invalid strings when none is given', () => {
+            const result = parseArea('invalid area');
+            expect(Object.hasOwn(result, 'spellAreaType')).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed area type names to a unified SpellArea* prefix and consolidated exports for simpler importing; public API names updated.
* **Bug Fixes**
  * Improved area-string parsing: clearer handling of sphere variants, stricter parameter extraction and numeric validation.
* **Tests**
  * Added comprehensive tests for stringify, tryParseArea, and parseArea across all area shapes, negative cases, and default handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->