### PR TITLE
refactor: cleanup Spell and related classes and improve test coverage

### DIFF
--- a/src/Magic/Spell/RankedSpell.ts
+++ b/src/Magic/Spell/RankedSpell.ts
@@ -1,24 +1,37 @@
-import type { RawSpellAsset, RawSpellBase } from '@wowfinder/asset-schemas';
-import type { School, SubSchool } from '@wowfinder/ts-enums';
-import {
-    Optional,
-    StringFormatter,
-    assertDefined,
-    toRoman,
-} from '@wowfinder/ts-utils';
+import type {
+    School,
+    SpellDescriptor,
+    SpellFlag,
+    SubSchool,
+} from '@wowfinder/ts-enums';
+import { StringFormatter, assertDefined, toRoman } from '@wowfinder/ts-utils';
 import type { ActionTime } from '../../Action/ActionTime';
 import { fullParseSchool } from '../School';
 import type { SpellDuration } from './Duration';
 import type { SpellRange } from './Range';
 import { SpellBase } from './base';
+import { SpellComponent } from './Components';
+import { SpellArea } from './Area';
+import { SpellSave } from './SpellSave';
 
-type RankedSpellBuilder = Omit<
-    Optional<
-        Required<RawSpellBase & RawSpellAsset>,
-        'area' | 'target' | 'trigger' | 'save'
-    >,
-    'ranks'
-> & { rank: number };
+type RankedSpellBuilder = {
+    key: string;
+    rank: number;
+    school: School | string;
+    subSchool?: SubSchool | string;
+    descriptors?: (SpellDescriptor | string)[];
+    components?: (SpellComponent | string)[];
+    castingTime: ActionTime | string;
+    range: SpellRange | string;
+    area?: SpellArea | string;
+    // effect: ???;
+    // targets: SpellTarget[];
+    duration: SpellDuration | string;
+    // effect: ???;
+    // targets: SpellTarget[];
+    save?: SpellSave | string;
+    flags?: (SpellFlag | string)[];
+};
 
 class RankedSpell extends SpellBase {
     readonly #key: string;

--- a/src/Magic/Spell/RankedSpell.ts
+++ b/src/Magic/Spell/RankedSpell.ts
@@ -28,7 +28,7 @@ type RankedSpellBuilder = {
     components?: PossiblyString<SpellComponent>[];
     castingTime: PossiblyString<ActionTime>;
     range: PossiblyString<SpellRange>;
-    area?: PossiblyString<SpellArea>;
+    area: PossiblyString<SpellArea>;
     // effect: ???;
     // targets: SpellTarget[];
     duration: PossiblyString<SpellDuration>;

--- a/src/Magic/Spell/RankedSpell.ts
+++ b/src/Magic/Spell/RankedSpell.ts
@@ -4,7 +4,12 @@ import type {
     SpellFlag,
     SubSchool,
 } from '@wowfinder/ts-enums';
-import { StringFormatter, assertDefined, toRoman } from '@wowfinder/ts-utils';
+import {
+    PossiblyString,
+    StringFormatter,
+    assertDefined,
+    toRoman,
+} from '@wowfinder/ts-utils';
 import type { ActionTime } from '../../Action/ActionTime';
 import { fullParseSchool } from '../School';
 import type { SpellDuration } from './Duration';
@@ -17,18 +22,18 @@ import { SpellSave } from './SpellSave';
 type RankedSpellBuilder = {
     key: string;
     rank: number;
-    school: School | string;
-    subSchool?: SubSchool | string;
-    descriptors?: (SpellDescriptor | string)[];
-    components?: (SpellComponent | string)[];
-    castingTime: ActionTime | string;
-    range: SpellRange | string;
-    area?: SpellArea | string;
+    school: PossiblyString<School>;
+    subSchool?: PossiblyString<SubSchool>;
+    descriptors?: PossiblyString<SpellDescriptor>[];
+    components?: PossiblyString<SpellComponent>[];
+    castingTime: PossiblyString<ActionTime>;
+    range: PossiblyString<SpellRange>;
+    area?: PossiblyString<SpellArea>;
     // effect: ???;
     // targets: SpellTarget[];
-    duration: SpellDuration | string;
-    save?: SpellSave | string;
-    flags?: (SpellFlag | string)[];
+    duration: PossiblyString<SpellDuration>;
+    save?: PossiblyString<SpellSave>;
+    flags?: PossiblyString<SpellFlag>[];
 };
 
 class RankedSpell extends SpellBase {

--- a/src/Magic/Spell/RankedSpell.ts
+++ b/src/Magic/Spell/RankedSpell.ts
@@ -27,8 +27,6 @@ type RankedSpellBuilder = {
     // effect: ???;
     // targets: SpellTarget[];
     duration: SpellDuration | string;
-    // effect: ???;
-    // targets: SpellTarget[];
     save?: SpellSave | string;
     flags?: (SpellFlag | string)[];
 };

--- a/src/Magic/Spell/Spell.ts
+++ b/src/Magic/Spell/Spell.ts
@@ -117,8 +117,6 @@ class Spell extends SpellBase {
         );
         assertDefined(rankObj.range, `Missing range for ${this.#key}:${rank}`);
         const builder = {
-            // TODO: This may break if / when area and/or components are not really strings
-            //   Ideally, the fix should be made in RankedSpell to accept pre-built args
             key: this.#key,
             rank,
             area: rankObj.area,

--- a/src/Magic/Spell/Spell.ts
+++ b/src/Magic/Spell/Spell.ts
@@ -48,6 +48,7 @@ class Spell extends SpellBase {
                     );
                 }
             };
+            rankAssert(!!rank.area, 'Missing area');
             rankAssert(!!rank.castingTime, 'Missing casting time');
             rankAssert(!!rank.range, 'Missing range');
             rankAssert(!!rank.duration, 'Missing duration');

--- a/src/Magic/Spell/Spell.ts
+++ b/src/Magic/Spell/Spell.ts
@@ -9,24 +9,10 @@ import { SpellBase } from './base';
 import { SpellRank } from './Rank';
 import { RankedSpell, type RankedSpellBuilder } from './RankedSpell';
 import { RawSpellAsset } from '@wowfinder/asset-schemas';
-import { parseIfNeeded } from '@wowfinder/ts-utils';
+import { assertDefined, parseIfNeeded } from '@wowfinder/ts-utils';
 import { SpellComponent, parseSpellComponent } from './Components';
 import { parseValidSpellDescriptors } from './Descriptor';
 import { parseValidFlags } from './Flags';
-
-type Spells = { [key: string]: Spell };
-
-function getFirstDefined<T>(
-    failMessage: string,
-    ...args: (T | undefined)[]
-): T {
-    for (const arg of args) {
-        if (arg !== undefined) {
-            return arg;
-        }
-    }
-    throw new Error(failMessage);
-}
 
 class Spell extends SpellBase {
     readonly #key: string;
@@ -62,12 +48,9 @@ class Spell extends SpellBase {
                     );
                 }
             };
-            rankAssert(
-                !!rank.castingTime || !!this.castingTime,
-                'Missing casting time',
-            );
-            rankAssert(!!rank.range || !!this.range, 'Missing range');
-            rankAssert(!!rank.duration || !!this.duration, 'Missing duration');
+            rankAssert(!!rank.castingTime, 'Missing casting time');
+            rankAssert(!!rank.range, 'Missing range');
+            rankAssert(!!rank.duration, 'Missing duration');
         }
         const schoolParsed = fullParseSchool(school ?? '');
         if (!schoolParsed) {
@@ -122,22 +105,28 @@ class Spell extends SpellBase {
         if (!rankObj) {
             throw new Error(`Invalid rank ${rank} for ${this.#key}`);
         }
-        const getProp = <T>(prop: keyof SpellRank & keyof Spell): T => {
-            return getFirstDefined<T>(
-                `Missing ${prop} for ${this.#key}:${rank}`,
-                rankObj[prop] as T,
-                this[prop] as T,
-            );
-        };
+
+        assertDefined(rankObj.area, `Missing area for ${this.#key}:${rank}`);
+        assertDefined(
+            rankObj.castingTime,
+            `Missing casting time for ${this.#key}:${rank}`,
+        );
+        assertDefined(
+            rankObj.duration,
+            `Missing duration for ${this.#key}:${rank}`,
+        );
+        assertDefined(rankObj.range, `Missing range for ${this.#key}:${rank}`);
         const builder = {
+            // TODO: This may break if / when area and/or components are not really strings
+            //   Ideally, the fix should be made in RankedSpell to accept pre-built args
             key: this.#key,
             rank,
-            area: (rankObj.area ?? this.area) as any,
-            castingTime: getProp('castingTime'),
-            components: this.#components as any,
+            area: rankObj.area,
+            castingTime: rankObj.castingTime,
+            components: this.#components,
             descriptors: [...this.#descriptors],
-            duration: getProp('duration'),
-            range: getProp('range'),
+            duration: rankObj.duration,
+            range: rankObj.range,
             flags: [...this.#flags],
             school: this.school,
         } satisfies RankedSpellBuilder;
@@ -146,24 +135,6 @@ class Spell extends SpellBase {
 
     get fullRanks(): RankedSpell[] {
         return this.#ranks.map(rank => this.getRank(rank.rank));
-    }
-
-    static build(raw: any): Spell {
-        return new Spell(raw);
-    }
-
-    static load(/* reThrowErrors = false */): Spells {
-        throw new Error('Not implemented');
-    }
-
-    static byKey(key: string): Spell;
-    static byKey(key: string, rank: number): RankedSpell;
-    static byKey(key: string, rank?: number): Spell | RankedSpell {
-        const spell = this.load()[key];
-        if (!spell) {
-            throw new Error(`Invalid spell key: ${key}`);
-        }
-        return rank === undefined ? spell : spell.getRank(rank);
     }
 }
 

--- a/src/Magic/Spell/__tests__/RankedSpell.test.ts
+++ b/src/Magic/Spell/__tests__/RankedSpell.test.ts
@@ -7,6 +7,7 @@ import { toRoman } from '@wowfinder/ts-utils';
 const yellowSnowBallRank2Builder = {
     key: 'yellowSnowBall',
     ...yellowSnowBall.ranks[1],
+    area: yellowSnowBall.ranks[1].area ?? 'point',
     range: yellowSnowBall.range ?? 'touch',
     duration: yellowSnowBall.duration ?? 'instantaneous',
     castingTime: yellowSnowBall.castingTime ?? 'standard',

--- a/src/Magic/Spell/__tests__/Spell.test.ts
+++ b/src/Magic/Spell/__tests__/Spell.test.ts
@@ -99,6 +99,10 @@ describe('Spell', () => {
                 const incomplete = {
                     ...yellowSnowBall,
                     [prop]: undefined,
+                    ranks: yellowSnowBall.ranks.map(r => ({
+                        ...r,
+                        [prop]: undefined,
+                    })),
                 } as RawSpellAsset;
                 expect(() => new Spell(incomplete)).toThrow(
                     /Invalid spell definition/,

--- a/src/Magic/Spell/__tests__/Spell.test.ts
+++ b/src/Magic/Spell/__tests__/Spell.test.ts
@@ -1,6 +1,8 @@
 import { Spell } from '../Spell';
 import { yellowSnowBall } from '../../../__mocks__';
 import { expectDefined, t } from './helpers';
+import { type RawSpellAsset } from '@wowfinder/asset-schemas';
+import { assertNonNil } from '@wowfinder/ts-utils';
 
 describe('Spell', () => {
     describe('constructor and getters', () => {
@@ -24,6 +26,8 @@ describe('Spell', () => {
                 expect(spell.flags.toSorted()).toEqual(
                     (yellowSnowBall.flags ?? []).toSorted(),
                 );
+                expect(spell.subschool).toBeUndefined();
+                expect(spell.schoolDescription).toEqual(yellowSnowBall.school);
             });
             describe('ranks', () => {
                 it('should have the correct number of ranks', () => {
@@ -54,7 +58,53 @@ describe('Spell', () => {
                         // TODO: save (pending implementations)
                     });
                 }
+                it('should return the full list of ranks', () => {
+                    const ranks = spell.fullRanks;
+                    expect(ranks.length).toBe(yellowSnowBall.ranks.length);
+                });
+                it('should throw when trying to get an invalid rank', () => {
+                    expect(() => spell.getRank(-1)).toThrow(/Invalid rank/);
+                    expect(() =>
+                        spell.getRank(yellowSnowBall.ranks.length + 1),
+                    ).toThrow(/Invalid rank/);
+                });
             });
+        });
+        it('should build an instance with minimal values', () => {
+            // @ts-expect-error explicitly testing fallback behaviour
+            const notSoYellow = {
+                ...yellowSnowBall,
+                descriptors: undefined,
+                components: undefined,
+                flags: undefined,
+            } as RawSpellAsset;
+            const spell = new Spell(notSoYellow);
+            expect(spell).toBeInstanceOf(Spell);
+            assertNonNil(spell.descriptors);
+            assertNonNil(spell.components);
+            assertNonNil(spell.flags);
+        });
+        it('should throw if school is invalid / unparseable', () => {
+            // @ts-expect-error explicitly testing fallback behaviour
+            const badSchool = {
+                ...yellowSnowBall,
+                school: undefined,
+            } as RawSpellAsset;
+            expect(() => new Spell(badSchool)).toThrow(/Invalid school/);
+        });
+        it('should throw if a rank is missing mandatory properties', () => {
+            const incomplete = {
+                ...yellowSnowBall,
+                ranks: [
+                    {
+                        ...yellowSnowBall.ranks[0],
+                        castingTime: undefined,
+                    },
+                ],
+            } as RawSpellAsset;
+            expect(() => new Spell(incomplete)).toThrow(
+                /Invalid spell definition/,
+            );
         });
     });
 });

--- a/src/Magic/Spell/__tests__/Spell.test.ts
+++ b/src/Magic/Spell/__tests__/Spell.test.ts
@@ -45,15 +45,13 @@ describe('Spell', () => {
                         const area = spellRank.area;
                         expectDefined(area);
                         expect(spellRank.castingTime).toBe(
-                            rank.castingTime ??
-                                yellowSnowBall.castingTime ??
-                                null,
+                            rank.castingTime ?? yellowSnowBall.castingTime,
                         );
                         expect(spellRank.range).toBe(
-                            rank.range ?? yellowSnowBall.range ?? null,
+                            rank.range ?? yellowSnowBall.range,
                         );
                         expect(spellRank.duration).toBe(
-                            rank.duration ?? yellowSnowBall.duration ?? null,
+                            rank.duration ?? yellowSnowBall.duration,
                         );
                         // TODO: save (pending implementations)
                     });
@@ -81,8 +79,11 @@ describe('Spell', () => {
             const spell = new Spell(notSoYellow);
             expect(spell).toBeInstanceOf(Spell);
             assertNonNil(spell.descriptors);
+            expect(spell.descriptors.length).toBe(0);
             assertNonNil(spell.components);
+            expect(spell.components.length).toBe(0);
             assertNonNil(spell.flags);
+            expect(spell.flags.length).toBe(0);
         });
         it('should throw if school is invalid / unparseable', () => {
             // @ts-expect-error explicitly testing fallback behaviour
@@ -92,19 +93,17 @@ describe('Spell', () => {
             } as RawSpellAsset;
             expect(() => new Spell(badSchool)).toThrow(/Invalid school/);
         });
-        it('should throw if a rank is missing mandatory properties', () => {
-            const incomplete = {
-                ...yellowSnowBall,
-                ranks: [
-                    {
-                        ...yellowSnowBall.ranks[0],
-                        castingTime: undefined,
-                    },
-                ],
-            } as RawSpellAsset;
-            expect(() => new Spell(incomplete)).toThrow(
-                /Invalid spell definition/,
-            );
-        });
+        it.each(['castingTime', 'range', 'duration'] as const)(
+            'should throw if %s is missing globally and in a rank',
+            prop => {
+                const incomplete = {
+                    ...yellowSnowBall,
+                    [prop]: undefined,
+                } as RawSpellAsset;
+                expect(() => new Spell(incomplete)).toThrow(
+                    /Invalid spell definition/,
+                );
+            },
+        );
     });
 });

--- a/src/Magic/Spell/base.ts
+++ b/src/Magic/Spell/base.ts
@@ -16,7 +16,7 @@ type SpellBaseBuilder = {
     // effect: ???;
     // targets: SpellTarget[];
     duration?: PossiblyString<SpellDuration>;
-    // savingThrow?: Save || false;
+    // save?: Save || false;
     flags?: PossiblyString<SpellFlag>[];
 };
 
@@ -26,8 +26,13 @@ abstract class SpellBase implements SpellBaseBuilder {
     readonly #area?: SpellArea;
     // #effect, #targets
     readonly #duration?: SpellDuration;
-    // #savingThrow
-    constructor({ castingTime, range, area, duration }: RawSpellBase) {
+    // #save
+    constructor({
+        castingTime,
+        range,
+        area,
+        duration,
+    }: RawSpellBase | SpellBaseBuilder) {
         this.#castingTime = parseIfNeeded(castingTime, ActionTime.tryParse);
         this.#range = parseIfNeeded(range, SpellRange.tryParse);
         this.#area = parseIfNeeded(area, parseArea);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Builder types made explicit (key, rank, school, components, casting time, range, area, duration, save, flags); public builder shape changed.
  - Per-rank fields (castingTime, range, duration, area) now required; fallbacks to base values removed.
  - Rank retrieval simplified with stricter validation and clearer errors.
  - Removed legacy static/key-based lookup APIs; constructors accept raw-like input or explicit builder.
  - Added public properties: subschool and schoolDescription.

- Tests
  - New tests for validation rules, rank access/errors, minimal construction, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->